### PR TITLE
게시글 API 구현 - 게시글 목록 조회

### DIFF
--- a/src/main/java/com/sparta/board/service/PostService.java
+++ b/src/main/java/com/sparta/board/service/PostService.java
@@ -6,6 +6,7 @@ import com.sparta.board.entity.Post;
 import com.sparta.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -24,7 +25,9 @@ public class PostService {
     }
 
     public List<PostResponse> getPosts() {
-        return null;
+        return postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdDateTime")).stream()
+                .map(PostResponse::from)
+                .toList();
     }
 
     public PostResponse getPost(Long id) {

--- a/src/test/java/com/sparta/board/controller/PostControllerTest.java
+++ b/src/test/java/com/sparta/board/controller/PostControllerTest.java
@@ -18,11 +18,17 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 
 @ExtendWith(SpringExtension.class)
@@ -110,5 +116,43 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.content").value(request.content()));
 
         // auditing 사용으로 실제 db 까지 안가서 날짜는 구분못하는데 괜찮은지?
+    }
+
+    @Test
+    @DisplayName("[Controller][POST] 게시글 목록 조회 성공")
+    void givenNothing_whenRequesting_thenSuccess() throws Exception {
+        //given
+        ArrayList<PostResponse> response = new ArrayList<>();
+        response.add(new PostResponse("testName1", "testTitle1", "testContent1", LocalDateTime.now()));
+        response.add(new PostResponse("testName2", "testTitle2", "testContent2", LocalDateTime.now()));
+        response.add(new PostResponse("testName3", "testTitle3", "testContent3", LocalDateTime.now()));
+
+        when(postService.getPosts()).thenReturn(response);
+        //when
+        ResultActions actions = mvc.perform(
+                get("/api/posts")
+        );
+
+        actions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("testName1")))
+                .andExpect(content().string(containsString("testName2")))
+                .andExpect(content().string(containsString("testName3")));
+    }
+
+    @Test
+    @DisplayName("[Controller][POST] 게시글 목록 없는 경우 조회")
+    void givenNothing_whenRequesting_thenNoContentSuccess() throws Exception {
+        //given
+        when(postService.getPosts()).thenReturn(List.of());
+        //when
+        ResultActions actions = mvc.perform(
+                get("/api/posts")
+        );
+
+        actions
+                .andDo(print())
+                .andExpect(status().isOk());
     }
 }

--- a/src/test/java/com/sparta/board/service/PostServiceTest.java
+++ b/src/test/java/com/sparta/board/service/PostServiceTest.java
@@ -1,6 +1,7 @@
 package com.sparta.board.service;
 
 import com.sparta.board.dto.request.PostRequest;
+import com.sparta.board.dto.response.PostResponse;
 import com.sparta.board.entity.Post;
 import com.sparta.board.repository.PostRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -9,8 +10,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
@@ -40,5 +47,41 @@ class PostServiceTest {
 
         // Then
         then(postRepository).should().save(any(Post.class));
+    }
+
+    @DisplayName("게시글이 0개일 때, 목록 조회")
+    @Test
+    void givenNothing_whenGetPosts_thenReturnEmptyList() {
+        // Given
+
+        // When
+        List<PostResponse> response = sut.getPosts();
+
+        // Then
+        assertThat(response).isEmpty();
+    }
+
+    @DisplayName("게시글이 3개일 때, 목록 조회 시 게시글 반환")
+    @Test
+    void givenNothing_whenGetPosts_thenReturnPosts() {
+        // Given
+        ArrayList<Post> posts = new ArrayList<>();
+        posts.add(new Post("testName1", "","testTitle1", "testContent1"));
+        posts.add(new Post("testName2", "","testTitle2", "testContent2"));
+        posts.add(new Post("testName3", "","testTitle3", "testContent3"));
+
+        given(postRepository.findAll(Sort.by(Sort.Direction.DESC, "createdDateTime"))).willReturn(posts);
+        // When
+        List<PostResponse> result = sut.getPosts();
+
+        // Then
+        assertThat(result).hasSize(3);
+        assertThat(result)
+                .extracting("name","title","content")
+                .containsExactly(
+                        tuple("testName1","testTitle1","testContent1"),
+                        tuple("testName2","testTitle2","testContent2"),
+                        tuple("testName3","testTitle3","testContent3")
+                );
     }
 }


### PR DESCRIPTION
게시글 목록 조회 API 구현완료.
다만 서비스 테스트코드에 내림차순 정렬을 어떻게 테스트할 지 고민해봐야 할 듯함