### PR TITLE
게시글 API 구현 - 게시글 수정

### DIFF
--- a/src/main/java/com/sparta/board/aop/ApiExceptionAdvice.java
+++ b/src/main/java/com/sparta/board/aop/ApiExceptionAdvice.java
@@ -1,0 +1,36 @@
+package com.sparta.board.aop;
+
+import com.sparta.board.exception.InvalidPasswordException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
+public class ApiExceptionAdvice {
+
+
+    /**
+     * [Exception] API 호출 시 PathVariable 에 없는 리소스 ID 값으로 조회하는 경우 예외 발생
+     *
+     * @param exception NoSuchElementException
+     * @return ResponseEntity<Map<String,String>>
+     */
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<Map<String,String>> noSuchElementExceptionHandler(NoSuchElementException exception) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("msg", exception.getMessage()));
+    }
+    /**
+     * [Exception] 수정, 삭제 시 입력한 비밀번호가 게시글의 비밀번호와 일치하지 않는 경우 예외 발생
+     *
+     * @param exception InvalidPasswordException
+     * @return ResponseEntity<Map<String,String>>
+     */
+    @ExceptionHandler(InvalidPasswordException.class)
+    public ResponseEntity<Map<String,String>> noSuchElementExceptionHandler(InvalidPasswordException exception) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("msg", exception.getMessage()));
+    }
+}

--- a/src/main/java/com/sparta/board/controller/PostController.java
+++ b/src/main/java/com/sparta/board/controller/PostController.java
@@ -56,7 +56,7 @@ public class PostController {
             @PathVariable(value = "postId") Long id,
             @RequestBody PostRequest request
     ) {
-        return null;
+        return ResponseEntity.ok(postService.updatePost(id, request));
 
     }
 

--- a/src/main/java/com/sparta/board/dto/response/PostResponse.java
+++ b/src/main/java/com/sparta/board/dto/response/PostResponse.java
@@ -5,6 +5,7 @@ import com.sparta.board.entity.Post;
 
 import java.time.LocalDateTime;
 public record PostResponse(
+        Long id,
         String name,
         String title,
         String content,
@@ -13,6 +14,7 @@ public record PostResponse(
 ) {
     public static PostResponse from(Post entity) {
         return new PostResponse(
+                entity.getId(),
                 entity.getName(),
                 entity.getTitle(),
                 entity.getContent(),

--- a/src/main/java/com/sparta/board/entity/Post.java
+++ b/src/main/java/com/sparta/board/entity/Post.java
@@ -1,5 +1,6 @@
 package com.sparta.board.entity;
 
+import com.sparta.board.dto.request.PostRequest;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,5 +36,11 @@ public class Post {
 
     public static Post of(String name, String password, String title, String content) {
         return new Post(name, password, title, content);
+    }
+
+    public void updatePost(PostRequest request) {
+        this.name = request.name();
+        this.title = request.title();
+        this.content = request.content();
     }
 }

--- a/src/main/java/com/sparta/board/exception/InvalidPasswordException.java
+++ b/src/main/java/com/sparta/board/exception/InvalidPasswordException.java
@@ -1,0 +1,7 @@
+package com.sparta.board.exception;
+
+public class InvalidPasswordException extends RuntimeException {
+    public InvalidPasswordException() {
+        super("비밀번호가 일치하지 않습니다.");
+    }
+}

--- a/src/main/java/com/sparta/board/service/PostService.java
+++ b/src/main/java/com/sparta/board/service/PostService.java
@@ -3,6 +3,7 @@ package com.sparta.board.service;
 import com.sparta.board.dto.request.PostRequest;
 import com.sparta.board.dto.response.PostResponse;
 import com.sparta.board.entity.Post;
+import com.sparta.board.exception.InvalidPasswordException;
 import com.sparta.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -39,7 +40,16 @@ public class PostService {
     }
 
     public PostResponse updatePost(Long postId, PostRequest request) {
-        return null;
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("수정할 게시글이 없습니다."));
+
+        if (!passwordEncoder.matches(request.password(), post.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+
+        post.updatePost(request);
+
+        return PostResponse.from(post);
     }
 
     public void deletePost(Long id, String password) {

--- a/src/test/java/com/sparta/board/controller/PostControllerTest.java
+++ b/src/test/java/com/sparta/board/controller/PostControllerTest.java
@@ -5,6 +5,7 @@ import com.sparta.board.config.AppConfig;
 import com.sparta.board.dto.request.PostRequest;
 import com.sparta.board.dto.response.PostResponse;
 import com.sparta.board.entity.Post;
+import com.sparta.board.exception.InvalidPasswordException;
 import com.sparta.board.service.PostService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,8 +28,8 @@ import java.util.NoSuchElementException;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -125,9 +126,9 @@ class PostControllerTest {
     void givenNothing_whenRequesting_thenSuccess() throws Exception {
         //given
         ArrayList<PostResponse> response = new ArrayList<>();
-        response.add(new PostResponse("testName1", "testTitle1", "testContent1", LocalDateTime.now()));
-        response.add(new PostResponse("testName2", "testTitle2", "testContent2", LocalDateTime.now()));
-        response.add(new PostResponse("testName3", "testTitle3", "testContent3", LocalDateTime.now()));
+        response.add(new PostResponse(1L, "testName1", "testTitle1", "testContent1", LocalDateTime.now()));
+        response.add(new PostResponse(2L, "testName2", "testTitle2", "testContent2", LocalDateTime.now()));
+        response.add(new PostResponse(3L, "testName3", "testTitle3", "testContent3", LocalDateTime.now()));
 
         when(postService.getPosts()).thenReturn(response);
         //when
@@ -204,5 +205,88 @@ class PostControllerTest {
                 .andDo(print())
                 .andExpect(status().is4xxClientError())
                 .andExpect(jsonPath("$.msg").value("조회할 게시글이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 정상 응답")
+    void givenUpdatePostInfo_whenRequesting_thenUpdate() throws Exception {
+        //Given
+        Long postId = 1L;
+        PostRequest request = PostRequest.of(
+                "updatedName",
+                "testPassword",
+                "updatedTitle",
+                "updatedContent"
+        );
+
+        Post updatedPost = Post.of("updatedName", "testPassword", "updatedTitle", "updatedContent");
+        when(postService.updatePost(postId, request)).thenReturn(
+                PostResponse.from(updatedPost)
+        );
+
+        //When
+        ResultActions actions = mvc.perform(
+                put("/api/posts/" + postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //Then
+        actions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(request.name()))
+                .andExpect(jsonPath("$.title").value(request.title()))
+                .andExpect(jsonPath("$.content").value(request.content()));
+    }
+
+    @Test
+    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 게시글이 없는 경우 예외 발생")
+    void givenUpdatePostInfo_whenRequesting_thenThrowException() throws Exception {
+        //Given
+        Long postId = 1L;
+        PostRequest request = PostRequest.of(
+                "updatedName",
+                "invalidPassword",
+                "updatedTitle",
+                "updatedContent"
+        );
+        when(postService.updatePost(postId, request)).thenThrow(new NoSuchElementException("조회할 게시글이 없습니다."));
+
+        //When
+        ResultActions actions = mvc.perform(
+                put("/api/posts/" + postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //Then
+        actions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.msg").value("조회할 게시글이 없습니다."));
+    }
+    @Test
+    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 비밀번호 다를 경우 예외 발생")
+    void givenUpdatePostInfoWithInvalidPassword_whenRequesting_thenThrowException() throws Exception {
+        //Given
+        Long postId = 1L;
+        PostRequest request = PostRequest.of(
+                "updatedName",
+                "invalidPassword",
+                "updatedTitle",
+                "updatedContent"
+        );
+        when(postService.updatePost(postId, request)).thenThrow(new InvalidPasswordException());
+
+        //When
+        ResultActions actions = mvc.perform(
+                put("/api/posts/" + postId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //Then
+        actions
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.msg").value("비밀번호가 일치하지 않습니다."));
     }
 }


### PR DESCRIPTION
게시글 수정 API 구현 완료

* 서비스 테스트에서 PasswordEncoder가 @Mock으로 가져올 떄, 암호화가 안됨, @Spy로 직접 객체를 가져와 사용하는 것으로 변경함
* 비밀번고 검증에 대한 커스텀 예외 작성함
* ControllerAdvice와 ExceptionHandler 어노테이션을 활용하여 각 예외 별로 응답 데이터를 핸들링함