### PR TITLE
게시글 API 구현 - 게시글 삭제

### DIFF
--- a/src/main/java/com/sparta/board/aop/ApiExceptionAdvice.java
+++ b/src/main/java/com/sparta/board/aop/ApiExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.sparta.board.aop;
 import com.sparta.board.exception.InvalidPasswordException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,7 +22,11 @@ public class ApiExceptionAdvice {
      */
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<Map<String,String>> noSuchElementExceptionHandler(NoSuchElementException exception) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("msg", exception.getMessage()));
+        String msg = "";
+        if (StringUtils.hasText(exception.getMessage())) {
+            msg = exception.getMessage();
+        }
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("msg", msg));
     }
     /**
      * [Exception] 수정, 삭제 시 입력한 비밀번호가 게시글의 비밀번호와 일치하지 않는 경우 예외 발생
@@ -31,6 +36,10 @@ public class ApiExceptionAdvice {
      */
     @ExceptionHandler(InvalidPasswordException.class)
     public ResponseEntity<Map<String,String>> noSuchElementExceptionHandler(InvalidPasswordException exception) {
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("msg", exception.getMessage()));
+        String msg = "";
+        if (StringUtils.hasText(exception.getMessage())) {
+            msg = exception.getMessage();
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("msg", msg));
     }
 }

--- a/src/main/java/com/sparta/board/controller/PostController.java
+++ b/src/main/java/com/sparta/board/controller/PostController.java
@@ -7,11 +7,13 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequestMapping("/api/posts")
@@ -61,10 +63,12 @@ public class PostController {
     }
 
     @DeleteMapping("/{postId}")
-    public ResponseEntity deletePost(
+    public ResponseEntity<?> deletePost(
             @PathVariable(value = "postId") Long id,
-            @RequestHeader("password") String password
+            @RequestHeader(value = "password") String password
     ) {
-        return null;
+        postService.deletePost(id, password);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/sparta/board/service/PostService.java
+++ b/src/main/java/com/sparta/board/service/PostService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -21,6 +22,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final PasswordEncoder passwordEncoder;
 
+    @Transactional
     public PostResponse createPost(PostRequest request) {
         Post post = postRepository.save(request.toEntity(passwordEncoder));
         return PostResponse.from(post);
@@ -54,6 +56,15 @@ public class PostService {
         return PostResponse.from(post);
     }
 
-    public void deletePost(Long id, String password) {
+    @Transactional
+    public void deletePost(Long postId, String password) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new NoSuchElementException("삭제할 게시글이 없습니다."));
+
+        if (!passwordEncoder.matches(password, post.getPassword())) {
+            throw new InvalidPasswordException();
+        }
+        postRepository.delete(post);
     }
+
 }

--- a/src/test/java/com/sparta/board/controller/PostControllerTest.java
+++ b/src/test/java/com/sparta/board/controller/PostControllerTest.java
@@ -189,7 +189,7 @@ class PostControllerTest {
     }
 
     @Test
-    @DisplayName("[Controller][GET] 게료시글 없는 상태에서 상세 조회 시 예외 발생")
+    @DisplayName("[Controller][GET] 없는 게시글 번호로 상세 조회 시 상태코드 404 반환")
     void givenPostId_whenRequesting_thenReturnThrow() throws Exception {
         //given
         Long postId = 1L;
@@ -240,7 +240,7 @@ class PostControllerTest {
     }
 
     @Test
-    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 게시글이 없는 경우 예외 발생")
+    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 게시글이 없는 경우  상태코드 404 반환")
     void givenUpdatePostInfo_whenRequesting_thenThrowException() throws Exception {
         //Given
         Long postId = 1L;
@@ -265,7 +265,7 @@ class PostControllerTest {
                 .andExpect(jsonPath("$.msg").value("조회할 게시글이 없습니다."));
     }
     @Test
-    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 비밀번호 다를 경우 예외 발생")
+    @DisplayName("[Controller][PUT] 게시글 수정 요청 시 비밀번호 다를 경우 상태코드 403 반환")
     void givenUpdatePostInfoWithInvalidPassword_whenRequesting_thenThrowException() throws Exception {
         //Given
         Long postId = 1L;

--- a/src/test/java/com/sparta/board/controller/PostControllerTest.java
+++ b/src/test/java/com/sparta/board/controller/PostControllerTest.java
@@ -27,6 +27,7 @@ import java.util.NoSuchElementException;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -288,5 +289,59 @@ class PostControllerTest {
         actions
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.msg").value("비밀번호가 일치하지 않습니다."));
+    }
+
+    @Test
+    @DisplayName("[Controller][DELETE] 게시글 삭제 요청 정상 호출")
+    void givenPostIdAndPassword_whenRequesting_thenSuccessNoContent() throws Exception {
+        //Given
+        Long postId = 1L;
+        String password = "testPassword";
+
+
+        //When
+        ResultActions actions = mvc.perform(
+                delete("/api/posts/" + postId)
+                        .header("password", password)
+        );
+
+        //Then
+        actions
+                .andExpect(status().isNoContent());
+    }
+    @Test
+    @DisplayName("[Controller][DELETE] 게시글 삭제 요청 시 비밀번호가 없는 경우 상태코드 400 반환")
+    void givenPostIdAndNoPassword_whenRequesting_thenThrowException() throws Exception {
+        //Given
+        Long postId = 1L;
+
+        //When
+        ResultActions actions = mvc.perform(
+                delete("/api/posts/" + postId)
+        );
+        //Then
+        actions
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[Controller][DELETE] 게시글 삭제 요청 시 비밀번호 다를 경우 상태코드 403 반환")
+    void givenPostIdAndInvalidPassword_whenRequesting_thenThrowException() throws Exception {
+        //Given
+        Long postId = 1L;
+        String password = "invalidPassword";
+
+        //When
+        doThrow(InvalidPasswordException.class).when(postService).deletePost(postId, password);
+
+        ResultActions actions = mvc.perform(
+                delete("/api/posts/" + postId)
+                        .header("password", password)
+        );
+
+
+        //Then
+        actions
+                .andExpect(status().isForbidden());
     }
 }

--- a/src/test/java/com/sparta/board/service/PostServiceTest.java
+++ b/src/test/java/com/sparta/board/service/PostServiceTest.java
@@ -151,7 +151,7 @@ class PostServiceTest {
                 .isInstanceOf(InvalidPasswordException.class);
     }
 
-    @DisplayName("없는 게시글의 ID를 입력하면, 예외를 발생한다.")
+    @DisplayName("수정 요청 시 없는 게시글의 ID를 입력하면, 예외를 발생한다.")
     @Test
     void givenInvalidPostId_whenUpdatingPost_thenThrowException() {
         // Given
@@ -159,6 +159,49 @@ class PostServiceTest {
 
         //When & Then
         Assertions.assertThatThrownBy(() -> sut.updatePost(2L, request))
+                .isInstanceOf(NoSuchElementException.class);
+    }
+
+    @DisplayName("삭제할 게시글의 ID와 비밀번호를 입력하면, 게시글을 삭제한다.")
+    @Test
+    void givenPostIdAndPassword_whenDeletingPost_thenDeletePost() {
+        // Given
+        Long postId = 1L;
+        Post post = createPost(postId);
+        String password = "testPassword";
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        //When
+        sut.deletePost(postId, password);
+        //Then
+        then(postRepository).should().delete(post);
+    }
+
+    @DisplayName("삭제할 게시글의 비밀번호를 다르게 입력하면, 예외를 발생한다.")
+    @Test
+    void givenInvalidPassword_whenDeletingPost_thenThrowException() {
+        // Given
+        Long postId = 1L;
+        Post post = createPost(postId);
+        ReflectionTestUtils.setField(post, "id", postId);
+        String password = "invalidPassword";
+
+        given(postRepository.findById(postId)).willReturn(Optional.of(post));
+
+        //When & Then
+        Assertions.assertThatThrownBy(() -> sut.deletePost(postId, password))
+                .isInstanceOf(InvalidPasswordException.class);
+    }
+
+    @DisplayName("삭제 요청시 없는 게시글의 ID를 입력하면, 예외를 발생한다.")
+    @Test
+    void givenInvalidPostId_whenDeleting_thenThrowException() {
+        // Given
+        Long postId = 1L;
+        String password = "testPassword";
+        //When & Then
+        Assertions.assertThatThrownBy(() -> sut.deletePost(postId, password))
                 .isInstanceOf(NoSuchElementException.class);
     }
 


### PR DESCRIPTION
81e2097
: 기존에 Map에 바로 exception.getMessage() 로 처리하였는데, 예외 메시지가 없는 경우 NPE가 날 수 있어
  if로 체크하여 value를 넣어주는 것으로 수정함

86309b9
: 테스트 제목을 예외가 발생 -> 발생한 경우의 해당하는 상태코드 반환으로 수정

282598a
: 게시글 삭제 API 구현 완료